### PR TITLE
refactor: move the test job to its own job script

### DIFF
--- a/src/@orb.yaml
+++ b/src/@orb.yaml
@@ -1,39 +1,8 @@
 version: 2.1
-orb:
-  gke:circleci/gcp-gke@1.3.0
 
-jobs:
-  test:
-    machine:
-      image: ubuntu-1604:202007-01
-    steps:
-      - checkout
-      - run:
-          name: test
-          command: << include(scripts/greet.sh) >>
-      - run:
-          name: hello
-          command: echo $cluster_kubernete >> /tmp/kubernetes.credentias
-      - run:
-          name: install kubectl
-          command: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-      - run:
-          name: check-kubernetes
-          command: kubectl version --client
-      - run:
-          name: Namespaces
-          command: kubectl get namespaces 
+description: >
+  Saúde iD kubernetes Orb
 
-
-usage:
-  version: 2.1
-  orbs:
-    kubernetes-gke-publish: saudeid/kubernetes-gke-publish@0.0.16
-
-  workflows:
-    build:
-      jobs:
-        - kubernetes-gke-publish/test:
-            context:
-            - dev
-    
+display:
+  home_url: "https://github.com/saude-id-tech/orbs"
+  source_url: "https://github.com/saude-id-tech/orbs"

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -1,0 +1,23 @@
+description: >
+  test
+
+machine:
+  image: ubuntu-1604:202007-01
+
+steps:
+  - checkout
+  - run:
+      name: test
+      command: << include(scripts/greet.sh) >>
+  - run:
+      name: hello
+      command: echo $cluster_kubernete >> /tmp/kubernetes.credentias
+  - run:
+      name: install kubectl
+      command: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+  - run:
+      name: check-kubernetes
+      command: kubectl version --client
+  - run:
+      name: Namespaces
+      command: kubectl get namespaces 


### PR DESCRIPTION
Please try to publish this to CircleCI orb after this pull request is accepted.

You should then be able to use this Orb in other projects like this:

```yml
# other project's .circleci/config.yml

version: 2.1
orbs:
  # please remember to use the latest version, after you published the Orb
  kubernetes-gke-publish: saudeid/kubernetes-gke-publish@<new version>

workflows:
  build:
    jobs:
      - kubernetes-gke-publish/test:
          context:
          - dev
```